### PR TITLE
Fix endTime calculation for SIGNAL TV sessions

### DIFF
--- a/src/hooks/useSignalTv.ts
+++ b/src/hooks/useSignalTv.ts
@@ -13,8 +13,10 @@ function extractNormalizedSchedule(data?: SignalTvApiResponse) {
 
   const sessions = [];
 
-  data
-    .filter((entry) => entry.has_cam)
+  const filteredData = data
+    .filter((entry) => entry.has_cam);
+
+  filteredData
     .forEach((entry, index) => {
       const speakers = entry.talent.map((name) => {
         const parts = name.trim().split(' ', 2);
@@ -27,7 +29,7 @@ function extractNormalizedSchedule(data?: SignalTvApiResponse) {
       const startDate = parse(entry.start.toString(), 't', new Date());
       let endDate: Date;
 
-      const nextEntry = data[index + 1];
+      const nextEntry = filteredData[index + 1];
       if (nextEntry) {
         // each session ends whenever the subsequent session begins
         endDate = parse(nextEntry.start.toString(), 't', new Date());


### PR DESCRIPTION
End time is calculated by checking the start time of the subsequent session in the list. The subsequent session was mistakenly being selected based on the original, unfiltered sessions list, resulting in an incorrect end time being calculated in some cases.

Before:

<img width="800" alt="Screen Shot 2021-10-20 at 8 20 42 AM" src="https://user-images.githubusercontent.com/115400/138104930-9797e594-b130-4ccf-8adb-885467f3274f.png">

After:

<img width="771" alt="Screen Shot 2021-10-20 at 8 36 38 AM" src="https://user-images.githubusercontent.com/115400/138104949-4509b9fe-f847-4d6b-9cec-101dadf3edaf.png">

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
