### PR TITLE
Improve hashes.json formatting, add example hash

### DIFF
--- a/api/assets/hashes.json
+++ b/api/assets/hashes.json
@@ -471,6 +471,16 @@
           "url": "https://www.twilio.com/docs/tutorials?filter-product=SMS"
         }
       ]
+    },
+    "f1fdf7": {
+      "name": "Example Hash",
+      "description": "We know this is supposed to be 7-characters but typos happen. Enjoy SIGNAL!",
+      "items": [
+        {
+          "type": "browser",
+          "url": "https://twil.io/signal2021-devs"
+        }
+      ]
     }
   }
 }

--- a/api/assets/hashes.json
+++ b/api/assets/hashes.json
@@ -203,263 +203,274 @@
       ]
     },
     "ed35f65": {
-        "name": "Superclass",
-        "description": "Find all information about Superclass",
-        "items": [{
-                "type": "browser",
-                "url": "https://twil.io/sc-signal2021"
-            },
-            {
-                "type": "browser",
-                "url": "https://twil.io/sc-agenda-signal2021"
-            }
-        ]
+      "name": "Superclass",
+      "description": "Find all information about Superclass",
+      "items": [
+        {
+          "type": "browser",
+          "url": "https://twil.io/sc-signal2021"
+        },
+        {
+          "type": "browser",
+          "url": "https://twil.io/sc-agenda-signal2021"
+        }
+      ]
     },
     "27e61f3": {
-        "name": "Superclass Kickstart: Introduction to APIs and Webhooks",
-        "description": "Find all relevant resources from the workshop",
-        "items": [{
-                "type": "browser",
-                "url": "https://signal.twilio.com/2021/sessions/664983"
-            },
-            {
-                "type": "browser",
-                "url": "https://github.com/TwilioDevEd/kickstart-apis-and-webhooks-workshop"
-            },
-            {
-                "type": "browser",
-                "url": "https://en.wikipedia.org/wiki/Representational_state_transfer#Architectural_constraints"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/docs/usage/webhooks/getting-started-twilio-webhooks"
-            }
-        ]
+      "name": "Superclass Kickstart: Introduction to APIs and Webhooks",
+      "description": "Find all relevant resources from the workshop",
+      "items": [
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/2021/sessions/664983"
+        },
+        {
+          "type": "browser",
+          "url": "https://github.com/TwilioDevEd/kickstart-apis-and-webhooks-workshop"
+        },
+        {
+          "type": "browser",
+          "url": "https://en.wikipedia.org/wiki/Representational_state_transfer#Architectural_constraints"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/docs/usage/webhooks/getting-started-twilio-webhooks"
+        }
+      ]
     },
     "3ee13aa": {
-        "name": "Superclass Kickstart: Serverless Twilio Tools",
-        "description": "Find all relevant resources from the workshop",
-        "items": [{
-                "type": "browser",
-                "url": "https://signal.twilio.com/2021/sessions/664985"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/docs/runtime/tutorials/twiml-bins"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/docs/runtime"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/docs/runtime/functions-assets-api/api/understanding-visibility-public-private-and-protected-functions-and-assets"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/docs/studio"
-            }
-        ]
+      "name": "Superclass Kickstart: Serverless Twilio Tools",
+      "description": "Find all relevant resources from the workshop",
+      "items": [
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/2021/sessions/664985"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/docs/runtime/tutorials/twiml-bins"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/docs/runtime"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/docs/runtime/functions-assets-api/api/understanding-visibility-public-private-and-protected-functions-and-assets"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/docs/studio"
+        }
+      ]
     },
     "727c371": {
-        "name": "Superclass: Programmable Voice",
-        "description": "Find all relevant resources from the workshop",
-        "items": [{
-                "type": "browser",
-                "url": "https://signal.twilio.com/2021/sessions/666941"
-            },
-            {
-                "type": "browser",
-                "url": "https://docs.google.com/presentation/d/1aUmbCrGB_oG_vPUPIxl9FKOi9ixWXIU0nxOZUIeaaYo/edit?usp=sharing"
-            },
-            {
-                "type": "browser",
-                "url": "https://github.com/bld010/SIGNAL2021-Superclass-Programmable-Voice"
-            },
-            {
-                "type": "browser",
-                "url": "https://signal.twilio.com/sessions?productFamily=Voice"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/code-exchange?q=&f=voice"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/docs/tutorials?filter-product=Voice"
-            }
-        ]
+      "name": "Superclass: Programmable Voice",
+      "description": "Find all relevant resources from the workshop",
+      "items": [
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/2021/sessions/666941"
+        },
+        {
+          "type": "browser",
+          "url": "https://docs.google.com/presentation/d/1aUmbCrGB_oG_vPUPIxl9FKOi9ixWXIU0nxOZUIeaaYo/edit?usp=sharing"
+        },
+        {
+          "type": "browser",
+          "url": "https://github.com/bld010/SIGNAL2021-Superclass-Programmable-Voice"
+        },
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/sessions?productFamily=Voice"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/code-exchange?q=&f=voice"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/docs/tutorials?filter-product=Voice"
+        }
+      ]
     },
     "a3e31a7": {
-        "name": "Superclass: Programmatic Email with Twilio SendGrid",
-        "description": "Find all relevant resources from the workshop",
-        "items": [{
-                "type": "browser",
-                "url": "https://signal.twilio.com/2021/sessions/666952"
-            },
-            {
-                "type": "browser",
-                "url": "https://github.com/TwilioDevEd/signal_superclass_2021_sendgrid"
-            },
-            {
-                "type": "browser",
-                "url": "https://signal.twilio.com/sessions?productFamily=Email"
-            }
-        ]
+      "name": "Superclass: Programmatic Email with Twilio SendGrid",
+      "description": "Find all relevant resources from the workshop",
+      "items": [
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/2021/sessions/666952"
+        },
+        {
+          "type": "browser",
+          "url": "https://github.com/TwilioDevEd/signal_superclass_2021_sendgrid"
+        },
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/sessions?productFamily=Email"
+        }
+      ]
     },
     "3e87cff": {
-        "name": "Superclass: Build a custom CDP solution with Twilio Segment",
-        "description": "Find all relevant resources from the workshop",
-        "items": [{
-                "type": "browser",
-                "url": "https://signal.twilio.com/2021/sessions/666749"
-            },
-            {
-                "type": "browser",
-                "url": "https://segment.com/twilio-developer-plan/"
-            },
-            {
-                "type": "browser",
-                "url": "https://gist.github.com/misteryeo/e17f2bd7cc4cd92b9f5e0a586c3a5706"
-            },
-            {
-                "type": "browser",
-                "url": "https://signal-ecommerce-site.vercel.app/"
-            },
-            {
-                "type": "browser",
-                "url": "https://gist.github.com/tysonmote/6169492b0f10c58d5965e7cb686df1e8"
-            }
-        ]
+      "name": "Superclass: Build a custom CDP solution with Twilio Segment",
+      "description": "Find all relevant resources from the workshop",
+      "items": [
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/2021/sessions/666749"
+        },
+        {
+          "type": "browser",
+          "url": "https://segment.com/twilio-developer-plan/"
+        },
+        {
+          "type": "browser",
+          "url": "https://gist.github.com/misteryeo/e17f2bd7cc4cd92b9f5e0a586c3a5706"
+        },
+        {
+          "type": "browser",
+          "url": "https://signal-ecommerce-site.vercel.app/"
+        },
+        {
+          "type": "browser",
+          "url": "https://gist.github.com/tysonmote/6169492b0f10c58d5965e7cb686df1e8"
+        }
+      ]
     },
     "8825cf5": {
-        "name": "Superclass: Building Telehealth with Twilio",
-        "description": "Find all relevant resources from the workshop",
-        "items": [{
-                "type": "browser",
-                "url": "https://signal.twilio.com/2021/sessions/666955"
-            },
-            {
-                "type": "browser",
-                "url": "https://github.com/TwilioDevEd/telehealth-video-workshop#prerequisites"
-            },
-            {
-                "type": "browser",
-                "url": "https://console.twilio.com/us1/billing/manage-billing/billing-overview"
-            },
-            {
-                "type": "browser",
-                "url": "https://signal.twilio.com/sessions?industry=HealthcareAndLifeSciences"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/code-exchange?q=&f=social_impact"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/code-exchange?q=&f=video"
-            }
-        ]
+      "name": "Superclass: Building Telehealth with Twilio",
+      "description": "Find all relevant resources from the workshop",
+      "items": [
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/2021/sessions/666955"
+        },
+        {
+          "type": "browser",
+          "url": "https://github.com/TwilioDevEd/telehealth-video-workshop#prerequisites"
+        },
+        {
+          "type": "browser",
+          "url": "https://console.twilio.com/us1/billing/manage-billing/billing-overview"
+        },
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/sessions?industry=HealthcareAndLifeSciences"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/code-exchange?q=&f=social_impact"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/code-exchange?q=&f=video"
+        }
+      ]
     },
     "c7a0636": {
-        "name": "Superclass: Developing a contact center with Twilio Flex",
-        "description": "Find all relevant resources from the workshop",
-        "items": [{
-                "type": "browser",
-                "url": "https://signal.twilio.com/2021/sessions/666948"
-            },
-            {
-                "type": "browser",
-                "url": "https://signal.twilio.com/sessions?productFamily=Flex"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/code-exchange?q=&f=flex"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/docs/flex"
-            },
-            {
-                "type": "browser",
-                "url": "https://twilio.learnupon.com/store"
-            }
-        ]
+      "name": "Superclass: Developing a contact center with Twilio Flex",
+      "description": "Find all relevant resources from the workshop",
+      "items": [
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/2021/sessions/666948"
+        },
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/sessions?productFamily=Flex"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/code-exchange?q=&f=flex"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/docs/flex"
+        },
+        {
+          "type": "browser",
+          "url": "https://twilio.learnupon.com/store"
+        }
+      ]
     },
     "d154440": {
-        "name": "Superclass: No code? No problem! Launch a verified broadcast SMS app in 5 minutes with Twilio Quick Deploy",
-        "description": "Find all relevant resources from the workshop",
-        "items": [{
-                "type": "browser",
-                "url": "https://signal.twilio.com/2021/sessions/692261"
-            },
-            {
-                "type": "browser",
-                "url": "https://signal.twilio.com/sessions?productFamily=AccountSecurity"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/code-exchange/verified-broadcast-sms"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/blog/verified-sms-broadcast-service-low-code"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/code-exchange?q=&f=verify"
-            }
-        ]
+      "name": "Superclass: No code? No problem! Launch a verified broadcast SMS app in 5 minutes with Twilio Quick Deploy",
+      "description": "Find all relevant resources from the workshop",
+      "items": [
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/2021/sessions/692261"
+        },
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/sessions?productFamily=AccountSecurity"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/code-exchange/verified-broadcast-sms"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/blog/verified-sms-broadcast-service-low-code"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/code-exchange?q=&f=verify"
+        }
+      ]
     },
     "e7190d7": {
-        "name": "Superclass: Programmable Video",
-        "description": "Find all relevant resources from the workshop",
-        "items": [{
-                "type": "browser",
-                "url": "https://signal.twilio.com/2021/sessions/666943"
-            },
-            {
-                "type": "browser",
-                "url": "https://signal.twilio.com/sessions?productFamily=Video"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/code-exchange?q=&f=video"
-            }
-        ]
+      "name": "Superclass: Programmable Video",
+      "description": "Find all relevant resources from the workshop",
+      "items": [
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/2021/sessions/666943"
+        },
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/sessions?productFamily=Video"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/code-exchange?q=&f=video"
+        }
+      ]
     },
     "0f021e0": {
-        "name": "Superclass: Programmable Messaging",
-        "description": "Find all relevant resources from the workshop",
-        "items": [{
-                "type": "browser",
-                "url": "https://signal.twilio.com/2021/sessions/664986"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/docs/sms/api/message-resource"
-            },
-            {
-                "type": "browser",
-                "url": "http://twil.io/cli"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/docs/messaging/guides/best-practices-at-scale"
-            },
-            {
-                "type": "browser",
-                "url": "https://signal.twilio.com/sessions?productFamily=Messaging"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/code-exchange?q=&f=sms&f=whatsapp"
-            },
-            {
-                "type": "browser",
-                "url": "https://www.twilio.com/docs/tutorials?filter-product=SMS"
-            }
-        ]
+      "name": "Superclass: Programmable Messaging",
+      "description": "Find all relevant resources from the workshop",
+      "items": [
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/2021/sessions/664986"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/docs/sms/api/message-resource"
+        },
+        {
+          "type": "browser",
+          "url": "http://twil.io/cli"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/docs/messaging/guides/best-practices-at-scale"
+        },
+        {
+          "type": "browser",
+          "url": "https://signal.twilio.com/sessions?productFamily=Messaging"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/code-exchange?q=&f=sms&f=whatsapp"
+        },
+        {
+          "type": "browser",
+          "url": "https://www.twilio.com/docs/tutorials?filter-product=SMS"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
This change applies consistent whitespace formatting to `hashes.json` and adds an example hash to be used in an upcoming presentation.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x ] I acknowledge that all my contributions will be made under the project's license.
