### PR TITLE
Simplify chat retrieval code, improve loading/refresh UX

### DIFF
--- a/src/components/panes/ChatPane.tsx
+++ b/src/components/panes/ChatPane.tsx
@@ -179,7 +179,7 @@ export const ChatPane = () => {
   const getContent = () => {
     if (loading) return loadingContent;
     if (syncError || chatError) return errorContent;
-    if (isOffline) return offlineContent;
+    if (isOffline && !channelsLoading) return offlineContent;
     return activeContent;
   };
 

--- a/src/components/panes/ChatPane.tsx
+++ b/src/components/panes/ChatPane.tsx
@@ -45,7 +45,7 @@ const errorContent = (
   </Text>
 );
 
-const loadingContent = <LoadingIndicator text="Loading SIGNAL Chat..." />;
+const loadingContent = <LoadingIndicator text="Connecting to SIGNAL Chat..." />;
 
 export const ChatPane = () => {
   const { dispatch: modeDispatch } = useMode();
@@ -53,7 +53,7 @@ export const ChatPane = () => {
   const [addMessage] = useMutation<MessageData, AddMessageInput>(
     AddMessageMutation
   );
-  const { error: syncError, loading, syncClient } = useSyncClient(
+  const { error: syncError, loading: syncLoading, syncClient } = useSyncClient(
     'NETWORKING_CHAT'
   );
   const {
@@ -129,7 +129,7 @@ export const ChatPane = () => {
   };
 
   const isActive =
-    !loading &&
+    !syncLoading &&
     !isOffline &&
     !messagesLoading &&
     !channelsLoading &&
@@ -177,7 +177,7 @@ export const ChatPane = () => {
   );
 
   const getContent = () => {
-    if (loading) return loadingContent;
+    if (syncLoading) return loadingContent;
     if (syncError || chatError) return errorContent;
     if (isOffline && !channelsLoading) return offlineContent;
     return activeContent;

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -49,7 +49,7 @@ export function useChat(syncClient: SyncClient | undefined, user: User) {
   const [activeChannelIndex, setActiveChannelIndex] = useState(0);
   const [messages, setMessages] = useState<Message[]>([]);
   const [messagesLoading, setMessagesLoading] = useState(false);
-  const [channelsLoading, setChannelsLoading] = useState(false);
+  const [channelsLoading, setChannelsLoading] = useState(true);
   const [error, setError] = useState<Error | undefined>();
   const [chatState, setChatState] = useState<ChatState>({
     creators: false,

--- a/src/hooks/useChat.ts
+++ b/src/hooks/useChat.ts
@@ -237,11 +237,8 @@ export function useChat(syncClient: SyncClient | undefined, user: User) {
       if (channelItem?.list) {
         setMessagesLoading(true);
         channelItem.list
-          .getItems({
-            // Grab from the end of the list so users see latest messages on first load. Needs to be 'desc' order to work
-            from: channelItem.list.lastEventId,
-            order: 'desc',
-          })
+          // Grab in descending order so that users can see latest messages on first load.
+          .getItems({ order: 'desc' })
           .then(({ items }) => {
             const initialMessages = items
               .reduce((acc: Message[], item) => {

--- a/src/hooks/useSyncClient.ts
+++ b/src/hooks/useSyncClient.ts
@@ -40,8 +40,10 @@ export function useSyncClient(feature: SyncAccessTokenInputs['feature']) {
           const client = new SyncClient(accessToken);
 
           const fetchNewToken = async () => {
+            setLoading(true);
             const updatedToken = await fetchAccessToken();
             client.updateToken(updatedToken);
+            setLoading(false);
           };
 
           client.on('tokenAboutToExpire', fetchNewToken);

--- a/src/hooks/useSyncClient.ts
+++ b/src/hooks/useSyncClient.ts
@@ -49,6 +49,9 @@ export function useSyncClient(feature: SyncAccessTokenInputs['feature']) {
           client.on('connectionError', (connectionError) => {
             console.debug('Connection error: ', connectionError.message);
             setError(connectionError);
+            client?.shutdown()?.finally(() => {
+              setSyncClient(undefined);
+            });
           });
           client.on(
             'connectionStateChange',
@@ -59,7 +62,9 @@ export function useSyncClient(feature: SyncAccessTokenInputs['feature']) {
                 newState === 'denied' ||
                 newState === 'error'
               ) {
-                setSyncClient(undefined);
+                client?.shutdown()?.finally(() => {
+                  setSyncClient(undefined);
+                });
               }
             }
           );
@@ -80,7 +85,7 @@ export function useSyncClient(feature: SyncAccessTokenInputs['feature']) {
         syncClient &&
         !['connecting', 'disconnected'].includes(syncClient.connectionState)
       ) {
-        syncClient?.shutdown();
+        syncClient.shutdown();
       }
     };
   }, [syncClient, fetchAccessToken, error]);

--- a/src/hooks/useSyncClient.ts
+++ b/src/hooks/useSyncClient.ts
@@ -49,9 +49,7 @@ export function useSyncClient(feature: SyncAccessTokenInputs['feature']) {
           client.on('connectionError', (connectionError) => {
             console.debug('Connection error: ', connectionError.message);
             setError(connectionError);
-            client?.shutdown()?.finally(() => {
-              setSyncClient(undefined);
-            });
+            setSyncClient(undefined);
           });
           client.on(
             'connectionStateChange',
@@ -62,9 +60,7 @@ export function useSyncClient(feature: SyncAccessTokenInputs['feature']) {
                 newState === 'denied' ||
                 newState === 'error'
               ) {
-                client?.shutdown()?.finally(() => {
-                  setSyncClient(undefined);
-                });
+                setSyncClient(undefined);
               }
             }
           );

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -1,6 +1,12 @@
 import { SyncList } from 'twilio-sync';
 
-export type Role = 'Explorer' | 'Attendee' | 'Creator' | 'Employee' | 'Sponsor';
+export type Role =
+  | 'Explorer'
+  | 'Attendee'
+  | 'Creator'
+  | 'Employee'
+  | 'Sponsor'
+  | 'Twilio Speaker';
 
 export interface MessageData {
   avatar?: string | null;


### PR DESCRIPTION
Turns out `from` [wasn't necessary](https://twilio.slack.com/archives/CGQPL0RPH/p1634750331314900).

- Code cleanup
- Properly display the sync loading spinner on chat load (not sure why this started to default to offline)
- Display loading spinner while token refresh is in progress; was showing a flash of the offline screen instead :(