### PR TITLE
Update demos.json to set all code exchange links to non-null

### DIFF
--- a/api/assets/demos.json
+++ b/api/assets/demos.json
@@ -26,7 +26,7 @@
 					"repo_link": "https://github.com/twilio/signal2021-devs"
 				}
 			],
-			"codeexchange_link": null,
+			"codeexchange_link": "https://github.com/twilio/signal2021-devs",
 			"quick_deploy_link": null,
 			"is_community": false
 		},
@@ -118,7 +118,7 @@
 					"repo_link": "https://github.com/TwilioQuest/twilioquest-extension-template"
 				}
 			],
-			"codeexchange_link": null,
+			"codeexchange_link": "https://github.com/TwilioQuest/twilioquest-extension-template",
 			"quick_deploy_link": null,
 			"is_community": false
 		},
@@ -132,7 +132,7 @@
 					"repo_link": "https://github.com/TwilioQuest/talon"
 				}
 			],
-			"codeexchange_link": null,
+			"codeexchange_link": "https://github.com/TwilioQuest/talon",
 			"quick_deploy_link": null,
 			"is_community": false
 		},


### PR DESCRIPTION
This change adds placeholder URLs to the few entries in `demos.json` that have a null `codeexchange_link` field.

Addresses #7.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
